### PR TITLE
Изменение максимального хп игрока на уровне движка

### DIFF
--- a/addons/sourcemod/scripting/ncrpg/ncrpg_Buffs.inc
+++ b/addons/sourcemod/scripting/ncrpg/ncrpg_Buffs.inc
@@ -1,10 +1,10 @@
 Handle hArraySlowTimers;
 Handle hArraySpeedTimers;
-Handle hTimerFreezing[MAXPLAYERS+1];	// Пусть живет
+Handle hTimerFreezing[MAXPLAYERS+1];	// Пусть живет // Пусть живет
 
 void ResetPlayerModification(client) {
 	SetMaxHP(client, 100);
-	SetEntityHealth(client,100);//???
+	SetEntityHealth(client,100); // Нужен на случай наследования игроком максимального хп прошлого игрока, если вдруг здоровье нового игрока не прокачано, случается лишь при первом спавне и если за 0.09 секунд он сумел получить лечение, или при SDKHook_GetMaxHealth с передачей туда MaxHP.
 	SetMaxSpeed(client, 1.0);
 	SetGravity(client, 1.0);
 	SetSlow(client, 0.0);

--- a/addons/sourcemod/scripting/ncrpg_HealthShotMaxHealth.sp
+++ b/addons/sourcemod/scripting/ncrpg_HealthShotMaxHealth.sp
@@ -1,0 +1,22 @@
+#include <NCIncs/ncrpg_Buffs>
+#include <sdkhooks>
+
+public Plugin myinfo = {
+	name = "[NCRPG] Healthshot max heal increaser",
+	author = "inklesspen",
+	version = "1.0",
+	description = "Increases max health for engine. Healthshot heal to max health of RPG"
+}
+
+public void OnClientPutInServer(int client)
+{
+	SDKHook(client, SDKHook_GetMaxHealth, OnGetMaxHealth)
+}
+
+public Action OnGetMaxHealth(int client, int &maxhealth)
+{
+	maxhealth = NCRPG_GetMaxHP(client)
+	if(maxhealth)
+		return Plugin_Changed
+	return Plugin_Continue
+}


### PR DESCRIPTION
С этим дополнением медшприц будет лечить до максимального хп игрока, установленного ядром
Вынесено в отдельный плагин для возможности выбора установки и не порчи внутренностей ядра
(Слишком малый код для создания отдельного ресурса, но если будет отклонено - попробую залить на hlmod)