### PR TITLE
Fix damage block when skill is blocked

### DIFF
--- a/addons/sourcemod/scripting/ncrpg_skill_adrenaline.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_adrenaline.sp
@@ -51,7 +51,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 		{
 			if(GetRandomFloat(0.0, 1.0) <= cfg_fChance*level)
 			{
-				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled) return Plugin_Continue;
 				NCRPG_Buffs(victim).Speed = NCRPG_Buffs(victim).Speed+(level*cfg_fAmount);
 				g_hPlayerIsAdrenalined[victim]=CreateTimer(cfg_fInterval,Timer_OnAdrenalineStop,victim,TIMER_FLAG_NO_MAPCHANGE);
 			}

--- a/addons/sourcemod/scripting/ncrpg_skill_attack_speed.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_attack_speed.sp
@@ -63,7 +63,7 @@ public Action Event_WeaponFire(Event event, const char[] name, bool dontBroadcas
 		if(!cfg_bRestrict) wpn =false;
 		if(!wpn)
 		{
-			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Handled;
+			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Continue;
 			int weapon = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
 			if(weapon != -1)
 			{

--- a/addons/sourcemod/scripting/ncrpg_skill_bouncebullets.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_bouncebullets.sp
@@ -70,7 +70,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 				if(cfg_bRestrict && !wpn)
 					return Plugin_Continue;
 				//PrintToChatAll("4");
-				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 				float victimloc[3]; float attackerloc[3]; float fv[3];
 				GetClientEyePosition(victim, victimloc);
 				GetClientEyePosition(attacker, attackerloc);

--- a/addons/sourcemod/scripting/ncrpg_skill_damage.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_damage.sp
@@ -74,7 +74,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 		if(level>0 && damage>=1.0)
 		{
 			if(cfg_bStaticChance){
-				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 				damage*= 1.0+cfg_fPercent*level;
 				NCRPG_SkillActivated(ThisSkillID,attacker);
 				return Plugin_Changed;
@@ -83,7 +83,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 			{
 				if(GetRandomFloat(0.0, 1.0) <= cfg_fChance*level)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 					if(cfg_bEffects)
 					{
 						float pos[3]; GetClientAbsOrigin(victim, pos); pos[2] += 65.0;

--- a/addons/sourcemod/scripting/ncrpg_skill_decoy_clone.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_decoy_clone.sp
@@ -44,7 +44,7 @@ public Action Event_DecoyStarted(Event event, const char[] name, bool dontBroadc
 		int level = NCRPG_GetSkillLevel(client, ThisSkillID);
 		if(level>0 && GetRandomFloat(0.0,1.0) < level*cfg_fPercent)
 		{
-			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Handled;
+			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Continue;
 			float pos[3];
 			pos[0] = event.GetFloat("x");
 			pos[1] = event.GetFloat("y");

--- a/addons/sourcemod/scripting/ncrpg_skill_engineer.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_engineer.sp
@@ -70,7 +70,7 @@ public Action Timer_engineer(Handle timer, any client) {
 					{
 						int armor = Client_GetArmor(i);
 						if(armor >= 100) return Plugin_Continue;
-						if(NCRPG_SkillActivate(ThisSkillID,client,i)>= Plugin_Handled) return Plugin_Handled;
+						if(NCRPG_SkillActivate(ThisSkillID,client,i)>= Plugin_Handled) return Plugin_Continue;
 						armor += level*cfg_iAmount;
 						if(armor > 100) armor = 100;
 						Client_SetArmor(i, armor);

--- a/addons/sourcemod/scripting/ncrpg_skill_evade.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_evade.sp
@@ -57,7 +57,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 			{
 				if(GetRandomFloat(0.0, 1.0) <= cfg_fPercent*level)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled) return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled) return Plugin_Continue;
 					if(cfg_bEffects)
 					{
 						float pos[3];

--- a/addons/sourcemod/scripting/ncrpg_skill_explode.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_explode.sp
@@ -64,7 +64,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast) 
 				{
 					if( IsValidPlayer( i, true )&& (GetClientTeam(i)!=GetClientTeam(victim)))
 					{
-						if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled) return Plugin_Handled;
+						if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled) return Plugin_Continue;
 						GetClientAbsOrigin(i,pos_v);
 						float distance=GetVectorDistance(pos_a,pos_v);
 						if(distance>range) return Plugin_Continue;

--- a/addons/sourcemod/scripting/ncrpg_skill_firetaser.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_firetaser.sp
@@ -63,7 +63,7 @@ public Action Event_WeaponFire(Event event, const char[] name, bool dontBroadcas
 					GetEntPropVector(client, Prop_Send, "m_vecOrigin", origin);
 					origin[2] += 50.0; AddInFrontOf(origin, angles, 5, origin);
 					int target = FindAliveTarget(client, origin, angles, target_pos);
-					if(NCRPG_SkillActivate(ThisSkillID,client,target)>= Plugin_Handled) return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,client,target)>= Plugin_Handled) return Plugin_Continue;
 					if (target > 0){ RocketAttack(client, origin, angles); }
 				}
 			}

--- a/addons/sourcemod/scripting/ncrpg_skill_frostnade.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_frostnade.sp
@@ -137,7 +137,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 			if(StrEqual(buffer, "hegrenade_projectile"))
 				if(level > 0)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 					float time = cfg_bStatTime?cfg_fTime:cfg_fTime*level;
 					
 					int array[Freezing];

--- a/addons/sourcemod/scripting/ncrpg_skill_frostp.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_frostp.sp
@@ -154,7 +154,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 			{
 				if(level > 0)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 					float time = cfg_bStatTime?cfg_fTime:cfg_fTime*level;
 					
 					int array[Freezing];

--- a/addons/sourcemod/scripting/ncrpg_skill_ghoul.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_ghoul.sp
@@ -64,7 +64,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast) 
 				
 				if(val)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 					NCRPG_SetMaxHP(attacker, NCRPG_GetMaxHP(attacker)+val);
 					SetEntityHealth(attacker, GetClientHealth(attacker)+val);
 					NCRPG_SkillActivated(ThisSkillID,attacker);

--- a/addons/sourcemod/scripting/ncrpg_skill_icestab.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_icestab.sp
@@ -137,7 +137,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 			if(IsAcitveWeaponKnife(attacker))
 				if(level > 0)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled) return Plugin_Changed;
 					float time = cfg_bStatTime?cfg_fTime:cfg_fTime*level;
 					
 					int array[Freezing];

--- a/addons/sourcemod/scripting/ncrpg_skill_incidence.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_incidence.sp
@@ -53,7 +53,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 		{
 			if( IsValidPlayer( i, true )&& (GetClientTeam(i)!=GetClientTeam(victim)))
 			{
-				if(NCRPG_SkillActivate(ThisSkillID,victim,i)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,victim,i)>= Plugin_Handled)return Plugin_Continue;
 				GetClientAbsOrigin(i,pos_v);
 				float distance=GetVectorDistance(pos_a,pos_v);
 				if(distance>cfg_fRange)

--- a/addons/sourcemod/scripting/ncrpg_skill_inhumanity.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_inhumanity.sp
@@ -49,7 +49,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 					GetClientAbsOrigin(victim,deathvec); GetClientAbsOrigin(i,gainhpvec);
 					if(GetVectorDistance(deathvec,gainhpvec)<=cfg_fRange*level)
 					{
-						if(NCRPG_SkillActivate(ThisSkillID,i,victim)>= Plugin_Handled)return Plugin_Handled;
+						if(NCRPG_SkillActivate(ThisSkillID,i,victim)>= Plugin_Handled)return Plugin_Continue;
 						NCRPG_Buffs(i).HealToMaxHP(amount);
 						NCRPG_SkillActivated(ThisSkillID,i);
 					}

--- a/addons/sourcemod/scripting/ncrpg_skill_longjump.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_longjump.sp
@@ -58,7 +58,7 @@ public Action Event_PlayerJump(Event event, const char[] name, bool dontBroadcas
 		int level = NCRPG_GetSkillLevel(client, ThisSkillID);
 		if(level > 0)
 		{
-			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Handled;
+			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Continue;
 			float velocity[3];
 			velocity[0] = GetEntDataFloat(client, m_vecVelocity_0)*cfg_fForce*level;
 			velocity[1] = GetEntDataFloat(client, m_vecVelocity_1)*cfg_fForce*level;

--- a/addons/sourcemod/scripting/ncrpg_skill_longjump2.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_longjump2.sp
@@ -65,7 +65,7 @@ public Action OnPlayerRunCmd(int client,int &buttons,int &impulse, float vel[3],
 	{
 		if(vVelocity[2] > g_fPreviousVelocity[client][2])
 		{
-			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Handled;
+			if(NCRPG_SkillActivate(ThisSkillID,client,client)>= Plugin_Handled)return Plugin_Continue;
 			HasJumped(client, vVelocity);
 			g_bPlayerStartedJumping[client] = false;
 			NCRPG_SkillActivated(ThisSkillID,client);

--- a/addons/sourcemod/scripting/ncrpg_skill_medic.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_medic.sp
@@ -80,7 +80,7 @@ public Action Timer_medic(Handle timer, int client) {
 					GetClientAbsOrigin(i,TeamPos);
 					if(GetVectorDistance(ClientPos, TeamPos, false) <= Range)
 					{
-						if(NCRPG_SkillActivate(ThisSkillID,client,i)>= Plugin_Handled)return Plugin_Handled;
+						if(NCRPG_SkillActivate(ThisSkillID,client,i)>= Plugin_Handled)return Plugin_Continue;
 						NCRPG_Buffs(i).HealToMaxHP(level*cfg_iAmount);
 						if(cfg_bEffects)
 						{

--- a/addons/sourcemod/scripting/ncrpg_skill_mirror_damage.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_mirror_damage.sp
@@ -50,7 +50,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 			int level = NCRPG_GetSkillLevel(victim, ThisSkillID);
 			if(level>0 && GetRandomFloat(0.0,100.0) < level*cfg_fChance)
 			{
-				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled)return Plugin_Continue;
 				float amount = (damage*level*cfg_fPercent);
 				if(amount>GetClientHealth(attacker)) amount = GetClientHealth(attacker)-amount-1;
 				NCRPG_DealDamage(attacker, RoundToNearest(amount), victim);

--- a/addons/sourcemod/scripting/ncrpg_skill_parasite.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_parasite.sp
@@ -52,7 +52,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 			{
 				if(bDucking[attacker])
 				{
-					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled)return Plugin_Continue;
 					float GlobPos[3];
 					GetClientAbsOrigin(victim, GlobPos);
 					TeleportEntity(attacker, GlobPos, NULL_VECTOR, NULL_VECTOR);

--- a/addons/sourcemod/scripting/ncrpg_skill_poisonsm.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_poisonsm.sp
@@ -140,7 +140,7 @@ public Action Timer_PoisonInterval(Handle timer) {
 				}
 				if(amount)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID, array[ownerIndex],client)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID, array[ownerIndex],client)>= Plugin_Handled)return Plugin_Continue;
 					NCRPG_DealDamage(client, amount, array[ownerIndex], DMG_POISON, "weapon_smokegrenade");
 					NCRPG_SkillActivated(ThisSkillID, array[ownerIndex]);
 				}

--- a/addons/sourcemod/scripting/ncrpg_skill_positionswap.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_positionswap.sp
@@ -81,7 +81,7 @@ public Action OnTakeDamage(int victim,int &attacker,int &inflictor,float &damage
 		{
 			if(level>0 && GetRandomFloat() < level*cfg_fPercent)
 			{
-				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled)return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,victim,attacker)>= Plugin_Handled)return Plugin_Continue;
 				GetClientAbsOrigin(victim, fPlayerLocation[victim]);
 				GetClientAbsOrigin(attacker, fPlayerLocation[attacker]);
 				TeleportEntity(victim, fPlayerLocation[attacker], NULL_VECTOR, NULL_VECTOR);

--- a/addons/sourcemod/scripting/ncrpg_skill_respawn.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_respawn.sp
@@ -52,7 +52,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 			{
 				if (iRespAmount[victim] < cfg_iAmount)
 				{
-					if(NCRPG_SkillActivate(ThisSkillID, victim,attacker)>= Plugin_Handled)return Plugin_Handled;
+					if(NCRPG_SkillActivate(ThisSkillID, victim,attacker)>= Plugin_Handled)return Plugin_Continue;
 					DataPack pack = new DataPack();pack.WriteCell(victim);
 					if(cfg_bType){
 						float fRespPos[3];

--- a/addons/sourcemod/scripting/ncrpg_skill_vampire.sp
+++ b/addons/sourcemod/scripting/ncrpg_skill_vampire.sp
@@ -58,7 +58,7 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 		{
 			if(GetRandomFloat(0.0, 1.0) <= cfg_fChance*level)
 			{
-				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled) return Plugin_Handled;
+				if(NCRPG_SkillActivate(ThisSkillID,attacker,victim)>= Plugin_Handled) return Plugin_Continue;
 				NCRPG_Buffs RPG_Player = NCRPG_Buffs(attacker);
 				int val = GetClientHealth(attacker);
 				if(val >= RPG_Player.MaxHP) return Plugin_Continue;


### PR DESCRIPTION
[RU]
Урон/таймер/событие блокировалось, если скилл был заблокирован
Например если произошла попытка заморозить и сработала антизаморозка, то урона не будет вовсе

Fixed modules:

- Adrenaline
- Speed -- blocks event
- Bounce Bullets
- Damage
- Decoy clone
- Engineer -- blocks timer
- Evade
- Explode
- Fire Taser -- blocks event
- Frost nade
- Frost pistol
- Ghoul
- Icestab
- Incidence
- Inhumanity
- Longjump -- blocks event
- Longjump2 -- blocks OnPlayerRunCmd (wtf)
- medic -- blocks times
- Mirror
- Parasite -- blocks event
- Poison smoke -- blocks timer
- respawn -- blocks event
- vampire